### PR TITLE
AbsoluteUrls does not work when using VirtualDocumentRoot.

### DIFF
--- a/extensions/AbsoluteUrls/AbsoluteUrls.php
+++ b/extensions/AbsoluteUrls/AbsoluteUrls.php
@@ -23,8 +23,11 @@ class Scaffold_Extension_AbsoluteUrls extends Scaffold_Extension
 	{
 		# We can only process files
 		if($source->path === false) return;
-
-		$relative_path = str_replace($_SERVER['DOCUMENT_ROOT'],'',dirname($source->path));
+		
+		# This will work with Apache VirtualDocumentRoot.
+		$root = str_replace($_SERVER['SCRIPT_NAME'],"",$_SERVER['SCRIPT_FILENAME']); 
+		
+		$relative_path = str_replace($root,'',dirname($source->path));
 	
 		# Process all @imports
 		if($found = $this->find_imports($source->contents))


### PR DESCRIPTION
$_SERVER['DOCUMENT_ROOT'] returns an erroneous value when used on a server configured with the apache VirtualDocumentRoot directive.

I modified the AbsoluteUrls extension to make it work using a famous trick which can be found on https://issues.apache.org/bugzilla/show_bug.cgi?id=26052.
